### PR TITLE
Fix build issues with missing build output path

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,7 @@ test: $(TARGET)
 $(TARGET): $(OBJ) Makefile
 	@mkdir -p bin
 	@echo linking $(TARGET) from $(OBJ)
+	mkdir -p ./build/usr/local/bin
 	@$(CC) $(OBJ) -o $(TARGET) $(LDFLAGS) -lm
 
 clean:


### PR DESCRIPTION
Build fails with the following error message:

compiling src/comexr-fan-control-he.c
linking ./build/usr/local/bin/comexr-fan-control-he from obj/comexr-fan-control-he.o
/home/linuxbrew/.linuxbrew/bin/ld: cannot open output file ./build/usr/local/bin/comexr-fan-control-he: No such file or directory
collect2: error: ld returned 1 exit status
make: *** [Makefile:30: build/usr/local/bin/comexr-fan-control-he] Error 1

Adding the build directory resolves this error and allows for the make install to complete correctly.